### PR TITLE
Fix to `Invalid value {}` when logging in to Google.

### DIFF
--- a/app/controllers/v1/Auth.ts
+++ b/app/controllers/v1/Auth.ts
@@ -789,7 +789,7 @@ export class AuthController extends Controller {
 
       // Check if user exists
       let user: User = await User.findOne({
-        where: { authProvider: {}, email },
+        where: { email },
         include: [
           { model: Profile, as: 'profile' },
           { model: AuthProvider, as: 'authProvider' }


### PR DESCRIPTION
This PR fixes the exception that is caught during login returning the following error:

```
Error on Google Login message=Invalid value {}, stack=Error: Invalid value {}
```